### PR TITLE
Added Ping, improved ITaskView and ChecksumFileSerializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Contains common utility classes for java.
 - [Build](#build)
 - [Sub Projects](#sub-projects)
 - [Supporting Projects](#supporting-projects)
-- [Screenshots]
+- [Screenshots](#screenshots)
 
 ## License
 
@@ -24,7 +24,7 @@ Run with:
 
 ## Build
 
-JUtils is built with it's own [bootstrap build system](./jbcs/readme.md). You must have javac in your path before running:
+JUtils is built with its own [bootstrap build system](./jbcs/readme.md). You must have javac in your path before running:
 
     cd <jutils_dir>
     javac -sourcepath ./jbcs/src -d ./jbcs/bin ./jbcs/src/jbcs/JbcsMain.java
@@ -66,68 +66,15 @@ If you would like to create a jar for easier use with other projects:
 
 ## Screenshots
 
-- [Apps Window](#apps-window)
-- [Hexedit Window](#hexedit-window)
-- [Hexulator Window](#hexulator-window)
-- [Multicon Window](#multicon-window)
-- [Kairosion Window](#kairosion-window)
-
-### Apps Window
-
-![JUtils Apps Window](./docs/apps_main.png)
-
-[Screenshots](#screenshots)
-
-### Hexedit Window
-
-![JUtils HexEdit Window](./docs/hexedit_main.png)
-
-[Screenshots](#screenshots)
-
-### Hexulator Window
-
-![Hexulator Window](./docs/hexulator.png)
-
-[Screenshots](#screenshots)
-
-### Multicon Window
-
-![Multicon Window](./docs/multicon.png)
-
-[Screenshots](#screenshots)
-
-### Kairosion Window
-
-![Kairosion Window](./docs/kairosion_main.png)
-
-[Screenshots](#screenshots)
-
-### Serial Console Window
-
-![Serial Console Window](./docs/serial_console_main.png)
-
-[Screenshots](#screenshots)
-
-### Filespy Window
-
-![Filespy Window](./docs/filespy_main.png)
-
-[Screenshots](#screenshots)
-
-### JChart Window
-
-![JChart Window](./docs/jchart_main.png)
-
-[Screenshots](#screenshots)
-
-### Summer Window
-
-![Summer Window](./docs/summer_main.png)
-
-[Screenshots](#screenshots)
-
-### Duak Window
-
-![Duak Window](./docs/duak_main.png)
-
-[Screenshots](#screenshots)
+| Application | Screenshot |
+| :--- | :--- |
+| **Apps Window** | ![JUtils Apps Window](./docs/apps_main.png) |
+| **HexEdit Window** | ![JUtils HexEdit Window](./docs/hexedit_main.png) |
+| **Hexulator Window** | ![Hexulator Window](./docs/hexulator.png) |
+| **Multicon Window** | ![Multicon Window](./docs/multicon.png) |
+| **Kairosion Window** | ![Kairosion Window](./docs/kairosion_main.png) |
+| **Serial Console Window** | ![Serial Console Window](./docs/serial_console_main.png) |
+| **Filespy Window** | ![Filespy Window](./docs/filespy_main.png) |
+| **JChart Window** | ![JChart Window](./docs/jchart_main.png) |
+| **Summer Window** | ![Summer Window](./docs/summer_main.png) |
+| **Duak Window** | ![Duak Window](./docs/duak_main.png) |

--- a/jutils.core/src/jutils/core/task/ITaskView.java
+++ b/jutils.core/src/jutils/core/task/ITaskView.java
@@ -2,33 +2,31 @@ package jutils.core.task;
 
 import java.awt.Component;
 import java.awt.event.ActionListener;
-
 import jutils.core.ui.model.IView;
 
 /*******************************************************************************
- * 
+ *
  ******************************************************************************/
-public interface ITaskView extends IView<Component>
-{
-    /***************************************************************************
-     * @param listener
-     **************************************************************************/
-    public void addCancelListener( ActionListener listener );
+public interface ITaskView extends IView<Component> {
+  /***************************************************************************
+   * @param listener
+   **************************************************************************/
+  void addCancelListener(ActionListener listener);
 
-    /***************************************************************************
-     * @param message
-     **************************************************************************/
-    public void signalMessage( String message );
+  /***************************************************************************
+   * @param message
+   **************************************************************************/
+  void signalMessage(String message);
 
-    /***************************************************************************
-     * @param percent
-     * @return {@code true} if the percent complete changed enough to issue the
-     * update; {@code false} otherwise.
-     **************************************************************************/
-    public boolean signalPercent( int percent );
+  /***************************************************************************
+   * @param percent
+   * @return {@code true} if the percent complete changed enough to issue the
+   * update; {@code false} otherwise.
+   **************************************************************************/
+  boolean signalPercent(int percent);
 
-    /***************************************************************************
-     * @param error
-     **************************************************************************/
-    public void signalError( TaskError error );
+  /***************************************************************************
+   * @param error
+   **************************************************************************/
+  void signalError(TaskError error);
 }

--- a/jutils.multicon/src/jutils/multicon/Ping.java
+++ b/jutils.multicon/src/jutils/multicon/Ping.java
@@ -1,0 +1,29 @@
+package jutils.multicon;
+
+import java.io.IOException;
+import java.net.InetAddress;
+
+/*******************************************************************************
+ *
+ ******************************************************************************/
+public class Ping {
+  /***************************************************************************
+   * Pings a specified host to test reachability
+   * @param host to ping, can be an IP address or domain name (e.g "8.8.8.8"
+   * or "google.com")
+   * @param timeoutMillis maximum time to wait for a response in milliseconds
+   * @return true, if host is reachable; false if otherwise.
+   **************************************************************************/
+  public static boolean executePing(String host, int timeoutMillis) {
+    try {
+      InetAddress address = InetAddress.getByName(host);
+      // Sends ICMP ECHO REQUESTs if privilige can be obtained. Otherwise,
+      // establish TCP connection on port 7 (Echo) of destination host.
+      return address.isReachable(timeoutMillis);
+    } catch (IOException ex) {
+      System.err.println("Host " + host +
+                         " is unreachable: " + ex.getStackTrace());
+      return false;
+    }
+  }
+}

--- a/jutils.summer/src/jutils/summer/io/ChecksumFileSerializer.java
+++ b/jutils.summer/src/jutils/summer/io/ChecksumFileSerializer.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-
 import jutils.core.ArrayPrinter;
 import jutils.core.Utils;
 import jutils.core.ValidationException;
@@ -19,235 +18,197 @@ import jutils.summer.data.ChecksumResult;
 import jutils.summer.data.SumFile;
 
 /*******************************************************************************
- * 
+ *
  *******************************************************************************/
-public class ChecksumFileSerializer implements IReader<ChecksumResult, File>
-{
-    /**  */
-    private static final SimpleDateFormat DATE_FMT = new SimpleDateFormat(
-        "M/d/YYYY h:mm:ss a" );
+public class ChecksumFileSerializer implements IReader<ChecksumResult, File> {
+  /**  */
+  private static final SimpleDateFormat DATE_FMT =
+      new SimpleDateFormat("M/d/YYYY h:mm:ss a");
 
-    /***************************************************************************
-     * 
-     **************************************************************************/
-    @Override
-    public ChecksumResult read( File file )
-        throws IOException, ValidationException
-    {
-        File parentFile = file.getAbsoluteFile().getParentFile();
+  /***************************************************************************
+   *
+   **************************************************************************/
+  @Override
+  public ChecksumResult read(File file)
+      throws IOException, ValidationException {
+    File parentFile = file.getAbsoluteFile().getParentFile();
 
-        ChecksumResult input = new ChecksumResult();
-        String ext = IOUtils.getFileExtension( file ).toUpperCase();
+    ChecksumResult input = new ChecksumResult();
+    String ext = IOUtils.getFileExtension(file).toUpperCase();
 
-        try
-        {
-            input.type = ChecksumType.valueOf( ext );
-            // JOptionPane.showMessageDialog(null, "Woot", "InfoBox: " + ext,
-            // JOptionPane.INFORMATION_MESSAGE);
-        }
-        catch( IllegalArgumentException ex )
-        {
-            throw new ValidationException(
-                "Incompatible extention, \"" + ext + "\". Must be one of " +
-                    ArrayPrinter.toString( ChecksumType.values() ),
-                ex );
-        }
-
-        input.commonDir = parentFile;
-
-        try( FileReader fr = new FileReader( file );
-             BufferedReader reader = new BufferedReader( fr ) )
-        {
-            String line;
-
-            while( ( line = reader.readLine() ) != null )
-            {
-                SumFile fs = new SumFile();
-
-                line = line.trim();
-
-                if( line.isEmpty() || line.charAt( 0 ) == '#' )
-                {
-                    continue;
-                }
-
-                int idx = line.indexOf( '*' );
-
-                if( idx > -1 && line.length() > idx )
-                {
-                    fs.checksum = line.substring( 0, idx ).trim().toLowerCase();
-                    fs.path = line.substring( idx + 1 ).trim();
-                    fs.file = new File( parentFile, fs.path );
-
-                    input.files.add( fs );
-                }
-            }
-        }
-
-        return input;
+    try {
+      input.type = ChecksumType.valueOf(ext);
+      // JOptionPane.showMessageDialog(null, "Woot", "InfoBox: " + ext,
+      // JOptionPane.INFORMATION_MESSAGE);
+    } catch (IllegalArgumentException ex) {
+      throw new ValidationException(
+          "Incompatible extention, \"" + ext + "\". Must be one of " +
+              ArrayPrinter.toString(ChecksumType.values()),
+          ex);
     }
 
-    /***************************************************************************
-     * @param results
-     * @return
-     **************************************************************************/
-    public static String write( ChecksumResult results )
-    {
-        StringBuilder str = new StringBuilder();
+    input.commonDir = parentFile;
 
-        if( results.type.name == "SHA-256" )
-        {
-            str.append( "# SHA-256 compliant checksum(s) " );
-        }
-        else if( results.type.name == "SHA-1" )
-        {
-            str.append( "# SHA-1 compliant checksum(s) " );
-        }
-        else if( results.type.name == "CRC-32" )
-        {
-            str.append( "# CRC-32 compliant checksum(s) " );
-        }
-        else if( results.type.name == "MD5" )
-        {
-            str.append(
-                "# MD5 checksums compatible with MD5summer (http://www.md5summer.org)" );
-        }
-        else
-        {
-            throw new IllegalStateException(
-                "checksum null for type " + results.type.name );
-        }
-        str.append( Utils.NEW_LINE );
-        str.append( "# Generated " );
-        str.append( DATE_FMT.format( new Date() ) );
-        str.append( Utils.NEW_LINE );
-        str.append( Utils.NEW_LINE );
+    try (FileReader fr = new FileReader(file);
+         BufferedReader reader = new BufferedReader(fr)) {
+      String line;
 
-        for( SumFile sf : results.files )
-        {
-            if( sf == null )
-            {
-                throw new IllegalStateException( "SumFile null" );
-            }
-            else if( sf.checksum == null )
-            {
-                throw new IllegalStateException(
-                    "checksum null for file " + sf.file );
-            }
+      while ((line = reader.readLine()) != null) {
+        SumFile fs = new SumFile();
 
-            str.append( sf.checksum.toLowerCase() );
-            str.append( " *" );
-            str.append( sf.path );
-            str.append( Utils.NEW_LINE );
+        line = line.trim();
+
+        if (line.isEmpty() || line.charAt(0) == '#') {
+          continue;
         }
 
-        return str.toString();
+        int idx = line.indexOf('*');
+
+        if (idx > -1 && line.length() > idx) {
+          fs.checksum = line.substring(0, idx).trim().toLowerCase();
+          fs.path = line.substring(idx + 1).trim();
+          fs.file = new File(parentFile, fs.path);
+
+          input.files.add(fs);
+        }
+      }
     }
 
-    /***************************************************************************
-     * @param input
-     * @param outputFile
-     * @throws FileNotFoundException
-     **************************************************************************/
-    public static void write( ChecksumResult input, File outputFile )
-        throws FileNotFoundException
-    {
-        try( PrintStream stream = new PrintStream( outputFile ) )
-        {
-            if( input.type.name == "SHA-256" )
-            {
-                stream.println( "# SHA-256 compliant checksum(s) " );
-            }
-            else if( input.type.name == "SHA-1" )
-            {
-                stream.println( "# SHA-1 compliant checksum(s) " );
-            }
-            else if( input.type.name == "CRC-32" )
-            {
-                stream.println( "# CRC-32 compliant checksum(s) " );
-            }
-            else if( input.type.name == "MD5" )
-            {
-                stream.println(
-                    "# MD5 checksums compatible with MD5summer (http://www.md5summer.org)" );
-            }
-            else
-            {
-                throw new IllegalStateException(
-                    "checksum null for type " + input.type.name );
-            }
+    return input;
+  }
 
-            stream.print( "# Generated " );
-            stream.println( DATE_FMT.format( new Date() ) );
-            stream.println();
+  /***************************************************************************
+   * @param results
+   * @return
+   **************************************************************************/
+  public static String write(ChecksumResult results) {
+    StringBuilder str = new StringBuilder();
 
-            for( SumFile sf : input.files )
-            {
-                stream.print( sf.checksum.toLowerCase() );
-                stream.print( " *" );
-                stream.println( sf.path );
-            }
-        }
+    switch (results.type.name) {
+    case "SHA-256":
+      str.append("# SHA-256 compliant checksum(s) ");
+      break;
+    case "SHA-1":
+      str.append("# SHA-1 compliant checksum(s) ");
+      break;
+    case "CRC-32":
+      str.append("# CRC-32 compliant checksum(s) ");
+      break;
+    case "MD5":
+      str.append("# MD5 checksums compatible with MD5summer "
+                 + "(http://www.md5summer.org)");
+      break;
+
+    default:
+      throw new IllegalStateException("checksum null for type " +
+                                      results.type.name);
     }
 
-    /***************************************************************************
-     * @param input
-     * @param outputFile
-     * @param append
-     * @param replace
-     * @throws IOException
-     * @throws ValidationException
-     **************************************************************************/
-    public void write( ChecksumResult results, File outputFile, boolean append,
-        boolean replace ) throws ValidationException, IOException
-    {
-        if( append && outputFile.canRead() )
-        {
-            ChecksumResult existing = read( outputFile );
+    str.append(Utils.NEW_LINE);
+    str.append("# Generated ");
+    str.append(DATE_FMT.format(new Date()));
+    str.append(Utils.NEW_LINE);
+    str.append(Utils.NEW_LINE);
 
-            results = merge( results, existing, replace );
-        }
+    for (SumFile sf : results.files) {
+      if (sf == null) {
+        throw new IllegalStateException("SumFile null");
+      } else if (sf.checksum == null) {
+        throw new IllegalStateException("checksum null for file " + sf.file);
+      }
 
-        write( results, outputFile );
+      str.append(sf.checksum.toLowerCase());
+      str.append(" *");
+      str.append(sf.path);
+      str.append(Utils.NEW_LINE);
     }
 
-    /***************************************************************************
-     * @param results
-     * @param existing
-     * @param replace
-     * @return
-     **************************************************************************/
-    private static ChecksumResult merge( ChecksumResult results,
-        ChecksumResult existing, boolean replace )
-    {
-        ChecksumResult merged = new ChecksumResult();
+    return str.toString();
+  }
 
-        merged.commonDir = results.commonDir;
+  /***************************************************************************
+   * @param input
+   * @param outputFile
+   * @throws FileNotFoundException
+   **************************************************************************/
+  public static void write(ChecksumResult input, File outputFile)
+      throws FileNotFoundException {
+    try (PrintStream stream = new PrintStream(outputFile)) {
+      if (input.type.name == "SHA-256") {
+        stream.println("# SHA-256 compliant checksum(s) ");
+      } else if (input.type.name == "SHA-1") {
+        stream.println("# SHA-1 compliant checksum(s) ");
+      } else if (input.type.name == "CRC-32") {
+        stream.println("# CRC-32 compliant checksum(s) ");
+      } else if (input.type.name == "MD5") {
+        stream.println("# MD5 checksums compatible with MD5summer "
+                       + "(http://www.md5summer.org)");
+      } else {
+        throw new IllegalStateException("checksum null for type " +
+                                        input.type.name);
+      }
 
-        if( replace )
-        {
-            merged.files.addAll( existing.files );
+      stream.print("# Generated ");
+      stream.println(DATE_FMT.format(new Date()));
+      stream.println();
 
-            for( SumFile sum : results.files )
-            {
-                for( SumFile es : existing.files )
-                {
-                    if( es.path.equals( sum.path ) )
-                    {
-                        merged.files.remove( es );
-                        break;
-                    }
-                }
-
-                merged.files.add( sum );
-            }
-        }
-        else
-        {
-            merged.files.addAll( existing.files );
-            merged.files.addAll( results.files );
-        }
-
-        return merged;
+      for (SumFile sf : input.files) {
+        stream.print(sf.checksum.toLowerCase());
+        stream.print(" *");
+        stream.println(sf.path);
+      }
     }
+  }
+
+  /***************************************************************************
+   * @param input
+   * @param outputFile
+   * @param append
+   * @param replace
+   * @throws IOException
+   * @throws ValidationException
+   **************************************************************************/
+  public void write(ChecksumResult results, File outputFile, boolean append,
+                    boolean replace) throws ValidationException, IOException {
+    if (append && outputFile.canRead()) {
+      ChecksumResult existing = read(outputFile);
+
+      results = merge(results, existing, replace);
+    }
+
+    write(results, outputFile);
+  }
+
+  /***************************************************************************
+   * @param results
+   * @param existing
+   * @param replace
+   * @return
+   **************************************************************************/
+  private static ChecksumResult
+  merge(ChecksumResult results, ChecksumResult existing, boolean replace) {
+    ChecksumResult merged = new ChecksumResult();
+
+    merged.commonDir = results.commonDir;
+
+    if (replace) {
+      merged.files.addAll(existing.files);
+
+      for (SumFile sum : results.files) {
+        for (SumFile es : existing.files) {
+          if (es.path.equals(sum.path)) {
+            merged.files.remove(es);
+            break;
+          }
+        }
+
+        merged.files.add(sum);
+      }
+    } else {
+      merged.files.addAll(existing.files);
+      merged.files.addAll(results.files);
+    }
+
+    return merged;
+  }
 }

--- a/todo.md
+++ b/todo.md
@@ -137,7 +137,6 @@
 
 ## jutils.multicon
 
-- Add ping
 - Add NTP
 - Add TFTP, FTP, SFTP clients and servers.
 - Add the ability to save pcapng files.


### PR DESCRIPTION
The README.md was made cleaner by using tables to demonstrate JUtils.
Fixed a critical string comparison that checks for reference instead of value in `ChecksumFileSerializer`.
According to [JLS 6](https://docs.oracle.com/javase/specs/jls/se7/html/jls-6.html#jls-6.6.1), interface methods are implicitly public. Declaring methods in interface `ITaskView` as public is redundant.
Implemented `Ping` under multicon.